### PR TITLE
cpu_context: Add missing include

### DIFF
--- a/exosphere/cpu_context.c
+++ b/exosphere/cpu_context.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include "cpu_context.h"
 #include "utils.h"
 #include "pmc.h"
 


### PR DESCRIPTION
Breaks out the one header not related to string.h from #17 