### PR TITLE
start.cold/warm.s: Correct DSB instruction instances

### DIFF
--- a/exosphere/start.cold.s
+++ b/exosphere/start.cold.s
@@ -49,7 +49,7 @@ __start_cold:
     mov  x0, #3
     msr  rmr_el3, x0
     isb
-    dsb
+    dsb  sy
     /* Nintendo forgot to copy-paste the branch instruction below. */
     _reset_wfi:
         wfi

--- a/exosphere/start.warm.s
+++ b/exosphere/start.warm.s
@@ -49,7 +49,7 @@ __start_warm:
     mov  x0, #3
     msr  rmr_el3, x0
     isb
-    dsb
+    dsb  sy
     /* Nintendo forgot to copy-paste the branch instruction below. */
     _reset_wfi:
         wfi


### PR DESCRIPTION
DSB requires specifying the barrier option