### PR TITLE
mmu: Remove phys_addr parameter from mmu_unmap_range

### DIFF
--- a/exosphere/mmu.h
+++ b/exosphere/mmu.h
@@ -163,7 +163,7 @@ static inline void mmu_map_page_range(uintptr_t *tbl, uintptr_t base_addr, uintp
     }
 }
 
-static inline void mmu_unmap_range(unsigned int level, uintptr_t *tbl, uintptr_t base_addr, uintptr_t phys_addr, size_t size) {
+static inline void mmu_unmap_range(unsigned int level, uintptr_t *tbl, uintptr_t base_addr, size_t size) {
     size = (size >> MMU_Lx_SHIFT(level)) << MMU_Lx_SHIFT(level);
     for(size_t offset = 0; offset < size; offset += MMU_Lx_SHIFT(level)) {
         mmu_unmap(level, tbl, base_addr + offset);


### PR DESCRIPTION
It's unused. I had intended to remove it in #27 but I must have forgotten to commit it.