### PR TITLE
timers: Fix identifier name in wait's spin-lock

### DIFF
--- a/exosphere/cpu_context.c
+++ b/exosphere/cpu_context.c
@@ -1,7 +1,8 @@
 #include <stdint.h>
 #include "cpu_context.h"
-#include "utils.h"
 #include "pmc.h"
+#include "timers.h"
+#include "utils.h"
 
 saved_cpu_context_t g_cpu_contexts[NUM_CPU_CORES] = {0};
 

--- a/exosphere/timers.c
+++ b/exosphere/timers.c
@@ -2,7 +2,7 @@
 
 void wait(uint32_t microseconds) {
     uint32_t old_time = TIMERUS_CNTR_1US_0;
-    while (TIMERUS_CNTR_1US_0 - old_time <= result) {
+    while (TIMERUS_CNTR_1US_0 - old_time <= microseconds) {
         /* Spin-lock. */
     }
 }


### PR DESCRIPTION
Also resolves implicit definition warnings for wait by including the necessary header where applicable

With this, it builds all the way to the assembly portion of compilation