### PR TITLE
se: Add missing string.h include

### DIFF
--- a/exosphere/se.c
+++ b/exosphere/se.c
@@ -1,5 +1,6 @@
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
 #include "utils.h"
 #include "mmu.h"


### PR DESCRIPTION
Resolves implicit declaration warnings for memcpy and memset. Must have missed this one in #17