### PR TITLE
smc_user: Add missing gcm.h include

### DIFF
--- a/exosphere/smc_user.c
+++ b/exosphere/smc_user.c
@@ -5,6 +5,7 @@
 #include "utils.h"
 #include "cache.h"
 #include "configitem.h"
+#include "gcm.h"
 #include "masterkey.h"
 #include "smc_api.h"
 #include "smc_user.h"


### PR DESCRIPTION
Resolves an implicit declaration warning for gcm_decrypt_key