### PR TITLE
lock: Use stdatomic.h

### DIFF
--- a/exosphere/src/lock.h
+++ b/exosphere/src/lock.h
@@ -1,25 +1,26 @@
 #ifndef EXOSPHERE_LOCK_H
 #define EXOSPHERE_LOCK_H
 
+#include <stdatomic.h>
 #include <stdbool.h>
 
 /* Simple atomics driver for Exosphere. */
 
 /* Acquire a lock. */
-static inline void lock_acquire(bool *l) {
-    while (__atomic_test_and_set(l, __ATOMIC_ACQUIRE)) {
+static inline void lock_acquire(atomic_flag *flag) {
+    while (atomic_flag_test_and_set_explicit(flag, memory_order_acquire)) {
         /* Wait to acquire lock. */
     }
 }
 
 /* Release a lock. */
-static inline void lock_release(bool *l) {
-    __atomic_clear(l, __ATOMIC_RELEASE);
+static inline void lock_release(atomic_flag *flag) {
+    atomic_flag_clear_explicit(flag, memory_order_release);
 }
 
 /* Try to acquire a lock. */
-static inline bool lock_try_acquire(bool *l) {
-    return __atomic_test_and_set(l, __ATOMIC_ACQUIRE);
+static inline bool lock_try_acquire(atomic_flag *flag) {
+    return atomic_flag_test_and_set_explicit(flag, memory_order_acquire);
 }
 
 #endif

--- a/exosphere/src/smc_api.c
+++ b/exosphere/src/smc_api.c
@@ -1,3 +1,4 @@
+#include <stdatomic.h>
 #include <stdint.h>
 
 #include "utils.h"
@@ -106,8 +107,8 @@ smc_table_t g_smc_tables[2] = {
     }
 };
 
-bool g_is_user_smc_in_progress = false;
-bool g_is_priv_smc_in_progress = false;
+static atomic_flag g_is_user_smc_in_progress = ATOMIC_FLAG_INIT;
+static atomic_flag g_is_priv_smc_in_progress = ATOMIC_FLAG_INIT;
 
 uintptr_t get_smc_core012_stack_address(void) {
     return tzram_get_segment_address(TZRAM_SEGMENT_ID_CORE012_STACK) + 0x1000;


### PR DESCRIPTION
Provides the same assembly output while also using the standardized interface

e.g. The identical output for both cases:

```
0000000000000000 <set_priv_smc_in_progress>:
   0:   90000000    adrp    x0, 0 <set_priv_smc_in_progress>
   4:   91000000    add x0, x0, #0x0
   8:   52800022    mov w2, #0x1                    // #1
   c:   d503201f    nop
  10:   085ffc01    ldaxrb  w1, [x0]
  14:   08037c02    stxrb   w3, w2, [x0]
  18:   35ffffc3    cbnz    w3, 10 <set_priv_smc_in_progress+0x10>
  1c:   72001c3f    tst w1, #0xff
  20:   54ffff81    b.ne    10 <set_priv_smc_in_progress+0x10>  // b.any
  24:   d65f03c0    ret
```